### PR TITLE
Remove References to Zone

### DIFF
--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go
@@ -84,7 +84,6 @@ func (aws *AwsCloudProvider) NodeGroupForNode(node *kube_api.Node) (cloudprovide
 
 // AwsRef contains a reference to some entity in AWS/GKE world.
 type AwsRef struct {
-	Zone string
 	Name string
 }
 
@@ -97,7 +96,6 @@ func AwsRefFromProviderId(id string) (*AwsRef, error) {
 	}
 	splitted := strings.Split(id[7:], "/")
 	return &AwsRef{
-		Zone: splitted[0],
 		Name: splitted[1],
 	}, nil
 }
@@ -192,7 +190,7 @@ func (asg *Asg) DeleteNodes(nodes []*kube_api.Node) error {
 
 // Id returns asg id.
 func (asg *Asg) Id() string {
-	return fmt.Sprintf("%s/%s", asg.Zone, asg.Name)
+	return asg.Name
 }
 
 // Debug returns a debug string for the Asg.
@@ -201,8 +199,8 @@ func (asg *Asg) Debug() string {
 }
 
 func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {
-	tokens := strings.SplitN(value, ":", 4)
-	if len(tokens) != 4 {
+	tokens := strings.SplitN(value, ":", 3)
+	if len(tokens) != 3 {
 		return nil, fmt.Errorf("wrong nodes configuration: %s", value)
 	}
 
@@ -228,12 +226,9 @@ func buildAsg(value string, awsManager *AwsManager) (*Asg, error) {
 	}
 
 	if tokens[2] == "" {
-		return nil, fmt.Errorf("asg zone must not be blank: %s got error: %v", tokens[2])
-	}
-	if tokens[3] == "" {
 		return nil, fmt.Errorf("asg name must not be blank: %s got error: %v", tokens[2])
 	}
-	asg.Zone = tokens[2]
-	asg.Name = tokens[3]
+
+	asg.Name = tokens[2]
 	return &asg, nil
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider_test.go
@@ -50,7 +50,7 @@ func TestAddNodeGroup(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, len(provider.asgs), 0)
 
-	err = provider.addNodeGroup("1:5:test-az:test-asg")
+	err = provider.addNodeGroup("1:5:test-asg")
 	assert.NoError(t, err)
 	assert.Equal(t, len(provider.asgs), 1)
 }
@@ -63,7 +63,7 @@ func TestName(t *testing.T) {
 func TestNodeGroups(t *testing.T) {
 	provider := testProvider(t)
 	assert.Equal(t, len(provider.NodeGroups()), 0)
-	err := provider.addNodeGroup("1:5:test-az:test-asg")
+	err := provider.addNodeGroup("1:5:test-asg")
 	assert.NoError(t, err)
 	assert.Equal(t, len(provider.NodeGroups()), 1)
 }
@@ -78,12 +78,12 @@ func TestAwsRefFromProviderId(t *testing.T) {
 
 	awsRef, err := AwsRefFromProviderId("aws:///test-az/test-instance-id")
 	assert.NoError(t, err)
-	assert.Equal(t, awsRef, &AwsRef{Zone: "test-az", Name: "test-instance-id"})
+	assert.Equal(t, awsRef, &AwsRef{Name: "test-instance-id"})
 }
 
 func TestMaxSize(t *testing.T) {
 	provider := testProvider(t)
-	err := provider.addNodeGroup("1:5:test-az:test-asg")
+	err := provider.addNodeGroup("1:5:test-asg")
 	assert.NoError(t, err)
 	assert.Equal(t, len(provider.asgs), 1)
 	assert.Equal(t, provider.asgs[0].MaxSize(), 5)
@@ -91,7 +91,7 @@ func TestMaxSize(t *testing.T) {
 
 func TestMinSize(t *testing.T) {
 	provider := testProvider(t)
-	err := provider.addNodeGroup("1:5:test-az:test-asg")
+	err := provider.addNodeGroup("1:5:test-asg")
 	assert.NoError(t, err)
 	assert.Equal(t, len(provider.asgs), 1)
 	assert.Equal(t, provider.asgs[0].MinSize(), 1)
@@ -100,7 +100,7 @@ func TestMinSize(t *testing.T) {
 // TODO: Mock aws api response
 // func TestTargetSize(t *testing.T) {
 // 	provider := testProvider(t)
-// 	err := provider.addNodeGroup("1:5:test-az:test-asg")
+// 	err := provider.addNodeGroup("1:5:test-asg")
 // 	assert.NoError(t, err)
 // 	assert.Equal(t, len(provider.asgs), 1)
 // 	targetSize, err := provider.asgs[0].TargetSize()
@@ -116,10 +116,10 @@ func TestMinSize(t *testing.T) {
 
 func TestId(t *testing.T) {
 	provider := testProvider(t)
-	err := provider.addNodeGroup("1:5:test-az:test-asg")
+	err := provider.addNodeGroup("1:5:test-asg")
 	assert.NoError(t, err)
 	assert.Equal(t, len(provider.asgs), 1)
-	assert.Equal(t, provider.asgs[0].Id(), "test-az/test-asg")
+	assert.Equal(t, provider.asgs[0].Id(), "test-asg")
 }
 
 func TestDebug(t *testing.T) {
@@ -128,9 +128,8 @@ func TestDebug(t *testing.T) {
 		minSize:    5,
 		maxSize:    55,
 	}
-	asg.Zone = "test-az"
 	asg.Name = "test-asg"
-	assert.Equal(t, asg.Debug(), "test-az/test-asg (5:55)")
+	assert.Equal(t, asg.Debug(), "test-asg (5:55)")
 }
 
 func TestBuildAsg(t *testing.T) {
@@ -143,10 +142,9 @@ func TestBuildAsg(t *testing.T) {
 	_, err = buildAsg("1:2:", nil)
 	assert.Error(t, err)
 
-	asg, err := buildAsg("111:222:test-az:test-name", nil)
+	asg, err := buildAsg("111:222:test-name", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 111, asg.MinSize())
 	assert.Equal(t, 222, asg.MaxSize())
-	assert.Equal(t, "test-az", asg.Zone)
 	assert.Equal(t, "test-name", asg.Name)
 }

--- a/cluster-autoscaler/cloudprovider/aws/aws_manager.go
+++ b/cluster-autoscaler/cloudprovider/aws/aws_manager.go
@@ -193,7 +193,7 @@ func (m *AwsManager) regenerateCache() error {
 		group := *groups.AutoScalingGroups[0]
 
 		for _, instance := range group.Instances {
-			ref := AwsRef{Zone: *instance.AvailabilityZone, Name: *instance.InstanceId}
+			ref := AwsRef{Name: *instance.InstanceId}
 			newCache[ref] = asg.config
 		}
 	}


### PR DESCRIPTION
As discussed on slack, were removing the requirement to include AZ for the first AWS implementation of the cluster autoscaler. 